### PR TITLE
Fix unhanded throwing of errors when using asynchronous mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ types.forEach(function (type) {
 // TO-DO: make this adaptive based on the initial signature of the image
 var bufferSize = 128*1024;
 
-function lookup (buffer, filepath, callback) {
+function lookup (buffer, filepath) {
   // detect the file type.. don't rely on the extension
   var type = detector(buffer, filepath);
 
@@ -26,35 +26,23 @@ function lookup (buffer, filepath, callback) {
   if (type in handlers) {
     var size = handlers[type].calculate(buffer, filepath);
     if (size !== false) {
-      if (callback) {
-        callback(null, size);
-      }
       return size;
     }
   }
 
   // throw up, if we don't understand the file
-  var err = new TypeError('unsupported file type');
-  if (callback) {
-    callback(err);
-  } else {
-    throw err;
-  }
+  throw new TypeError('unsupported file type');
 }
 
 function asyncFileToBuffer (filepath, buffer, callback) {
   // open the file in read only mode
   fs.open(filepath, 'r', function (err, descriptor) {
-    if (err) { throw err; }
+    if (err) { return callback(err); }
     // read first buffer block from the file, asynchronously
     fs.read(descriptor, buffer, 0, bufferSize, 0, function (err) {
-      if (err) { throw err; }
+      if (err) { return callback(err); }
       // close the file, we are done
-      fs.close(descriptor, function (err) {
-        if (err) { throw err; }
-        // no errors, return the buffer
-        callback();
-      });
+      fs.close(descriptor, callback);
     });
   });
 }
@@ -89,9 +77,15 @@ module.exports = function (input, callback) {
   var buffer = new Buffer(bufferSize);
 
   if (typeof callback === 'function') {
-    asyncFileToBuffer(filepath, buffer, function () {
+    asyncFileToBuffer(filepath, buffer, function (err) {
+      if (err) { return callback(err); }
+
       // return the dimensions
-      lookup(buffer, filepath, callback);
+      try {
+        callback(null, lookup(buffer, filepath));
+      } catch (err) {
+        callback(err);
+      }
     });
   } else {
     syncFileToBuffer(filepath, buffer);

--- a/specs/invalid.spec.js
+++ b/specs/invalid.spec.js
@@ -14,12 +14,39 @@ describe('Invalid Images', function () {
 
       var calculate = imageSize.bind(null, file);
 
-      it('should throw', function() {
+      it('should throw when called synchronously', function() {
         expect(calculate).to.throwException(function (e) {
           expect(e).to.be.a(TypeError);
           expect(e.message).to.match(/^invalid \w+$/);
         });
       });
+
+      it('should callback with error when called asynchronously', function(done) {
+        calculate(function (e, size) {
+          expect(e).to.be.a(TypeError);
+          expect(e.message).to.match(/^invalid \w+$/);
+          done();
+        });
+      });
     });
   });
+
+   describe('non-existent file', function() {
+
+      var calculate = imageSize.bind(null, 'fakefile.jpg');
+
+      it('should throw when called synchronously', function() {
+        expect(calculate).to.throwException(function (e) {
+          expect(e).to.be.a(Error);
+          expect(e.message).to.match(/^ENOENT.*$/);
+        });
+      });
+
+      it('should callback with error when called asynchronously', function(done) {
+        calculate(function (e, size) {
+          expect(e.message).to.match(/^ENOENT.*$/);
+          done();
+        });
+      });
+    });
 });


### PR DESCRIPTION
This closes issues #17 and #18 by making `asyncFileToBuffer` and `lookup` properly handle asynchronous errors. The tests have also been updated to test the asynchronous error cases.
