### PR TITLE
Remove unnecessary rules from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
 .coveralls.yml
-.DS_Store
-.git*
 .jshintrc
 .travis.yml
 coverage.html


### PR DESCRIPTION
`.DS_Store`, `.git` and `.gitignore` are ignored by default. See the npm developer guide, [_Keeping files out of your package_](https://www.npmjs.org/doc/misc/npm-developers.html#keeping-files-out-of-your-package).
