### PR TITLE
Support all JPGs rather than specific JFIF ones

### DIFF
--- a/lib/types/jpg.js
+++ b/lib/types/jpg.js
@@ -5,44 +5,10 @@
 // with a maximum size of 4096 bytes. so if the SOF marker is outside
 // if this range we can't detect the file size correctly.
 
-// TO-DO: handle all JFIFs
-var validJFIFMarkers = {
-  'ffdb': '0001010101', // Samsung D807 JPEG
-  'ffe0': '4a46494600', // Standard JPEG
-  'ffe1': '4578696600', // Camera JPEG, with EXIF data
-  'ffe2': '4943435f50', // Canon EOS-1D JPEG
-  'ffe3': '',           // Samsung D500 JPEG
-  'ffe8': '5350494646', // SPIFF JPEG
-  'ffec': '4475636b79', // Photoshop JPEG
-  'ffed': '50686f746f', // Adobe JPEG, Photoshop CMYK buffer
-  'ffee': '41646f6265'  // Adobe JPEG, Unrecognised (Lightroom??)
-};
-
-var red = ['\x1B[31m', '\x1B[39m'];
 function isJPG (buffer) { //, filepath
   var SOIMarker = buffer.toString('hex', 0, 2);
-  var JFIFMarker = buffer.toString('hex', 2, 4);
 
-  // not a valid jpeg
-  if ('ffd8' !== SOIMarker) {
-    return false;
-  }
-
-  // TO-DO: validate the end-bytes of a jpeg file
-  // use filepath, get the last bytes, check for ffd9
-  var got = buffer.toString('hex', 6, 11);
-  var expected = JFIFMarker && validJFIFMarkers[JFIFMarker];
-  if (expected === '') {
-    console.warn(
-      red[0] +
-      'this looks like a unrecognised jpeg\n' +
-      'please report the issue here\n' +
-      red[1],
-      '\thttps://github.com/netroy/image-size/issues/new\n'
-    );
-    return false;
-  }
-  return (got === expected) || (JFIFMarker === 'ffdb');
+  return ('ffd8' === SOIMarker);
 }
 
 function extractSize (buffer, i) {


### PR DESCRIPTION
For the purposes of this library requiring JPEGs use the JFIF standard doesn't seem necessary. Old school non-JFIF jpegs, like the kind produced by ffmpeg, aren't usable as-is.

Since there was only a limited set of markers in the list and a TODO to support all I've just removed the JFIF requirement entirely. JFIF will still work fine but now so will all valid JPEGs.