### PR TITLE
don't round values from SVG

### DIFF
--- a/lib/types/svg.js
+++ b/lib/types/svg.js
@@ -15,8 +15,8 @@ var extractorRegExps = {
 function parseViewbox (viewbox) {
   var bounds = viewbox.split(' ');
   return {
-    'width': parseInt(bounds[2], 10),
-    'height': parseInt(bounds[3], 10)
+    'width': parseFloat(bounds[2]),
+    'height': parseFloat(bounds[3])
   };
 }
 
@@ -25,8 +25,8 @@ function parseAttributes (root) {
   var height = root.match(extractorRegExps.height);
   var viewbox = root.match(extractorRegExps.viewbox);
   return {
-    'width': width && parseInt(width[2], 10),
-    'height': height && parseInt(height[2], 10),
+    'width': width && parseFloat(width[2]),
+    'height': height && parseFloat(height[2]),
     'viewbox': viewbox && parseViewbox(viewbox[2])
   };
 }


### PR DESCRIPTION
Unlike bitmap images, vector graphics can have fractional dimensions, rounding to int of which can fully invalidate the width/height information extracted. This patch switches out parseInt for parseFloat to make sure the fractional part of dimensions is preserved.
