### PR TITLE
Bug fix: when file size is 0, binding.read: Offset is out of bound

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ function asyncFileToBuffer (filepath, callback) {
   fs.open(filepath, 'r', function (err, descriptor) {
     if (err) { return callback(err); }
     var size = fs.fstatSync(descriptor).size;
+    if (size <= 0){return callback(new Error("File size is not greater than 0 —— " + filepath)); }
     var bufferSize = Math.min(size, MaxBufferSize);
     var buffer = new Buffer(bufferSize);
     // read first buffer block from the file, asynchronously


### PR DESCRIPTION
I'm working on a project using this module, and it's been very helpful. Thanks.

For testing purpose, I generated a large set (thousands) of empty files with valid image file names, and use "image-size" module as a part of the process, and ran into the error shown below:

``` javascript
fs.js:620
  binding.read(fd, buffer, offset, length, position, req);
          ^

Error: Offset is out of bounds
    at Error (native)
    at Object.fs.read (fs.js:620:11)
    at C:\_workBench\file-organizer\node_modules\image-size\lib\index.js:46:8
    at FSReqWrap.oncomplete (fs.js:82:15)
```

This may be a special case, but the fix would prevent empty "image" files from breaking the program, and could be useful when testing.
