### PR TITLE
tif for Nikon without tags

### DIFF
--- a/lib/types/tiff.js
+++ b/lib/types/tiff.js
@@ -63,7 +63,7 @@ function extractTags (buffer, isBigEndian) {
     } else {
       // 256 is width, 257 is height
       // if (code === 256 || code === 257) {
-      if (length === 1 && type === 3) {
+      if (length === 1 && (type === 3 || type === 4)) {
         tags[code] = readValue(buffer, isBigEndian);
       }
 


### PR DESCRIPTION
I have used Nikon D800 and the tags for width / height had length 4, not 3

For now I forked the project, but think it would be useful to allow both lengths

```sh
$ exiftool -v 6689.TIF
  ExifToolVersion = 10.13
  FileName = 6689.TIF
  Directory = tmp
  FileSize = 108477354
  FileModifyDate = 1462025121
  FileAccessDate = 1462245156
  FileInodeChangeDate = 1462243754
  FilePermissions = 33188
  FileType = TIFF
  FileTypeExtension = TIF
  MIMEType = image/tiff
  ExifByteOrder = II
  + [IFD0 directory with 25 entries]
  | 0)  SubfileType = 0
  | 1)  ImageWidth = 4912
  | 2)  ImageHeight = 7360
```