### PR TITLE
Fix regexp pattern of GIF signature

### DIFF
--- a/lib/types/gif.js
+++ b/lib/types/gif.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gifRegexp = /^GIF8[7,9]a/;
+var gifRegexp = /^GIF8[79]a/;
 function isGIF (buffer) {
   var signature = buffer.toString('ascii', 0, 6);
   return (gifRegexp.test(signature));


### PR DESCRIPTION
`[7,9]` matches `7`, `9`, and `,`.

``` javascript
> /^GIF8[7,9]a/.test('GIF8,a')
true
> /^GIF8[79]a/.test('GIF8,a')
false
```