### PR TITLE
chore: cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 git:
   depth: 1
 language: node_js
-cache: yarn
+cache:
+  directories:
+    - node_modules
 node_js:
   - 4
   - 6


### PR DESCRIPTION
yarn is not used anymore as there is no yarn.lock and setup uses `npm`, see https://travis-ci.org/image-size/image-size/jobs/317317696#L473

And we can optionally use the direct cache of npm.