### PR TITLE
Parse CSS units in SVG lengths

### DIFF
--- a/lib/types/svg.js
+++ b/lib/types/svg.js
@@ -12,11 +12,29 @@ var extractorRegExps = {
   'viewbox': /\bviewBox=(['"])(.+?)\1/
 };
 
+var units = {
+  'cm': 96/2.54,
+  'mm': 96/2.54/10,
+  'm':  96/2.54*100,
+  'pt': 96/72,
+  'pc': 96/72/12,
+  'em': 16,
+  'ex': 8,
+};
+
+function parseLength (len) {
+  var m = /([0-9.]+)([a-z]*)/.exec(len);
+  if (!m) {
+    return undefined;
+  }
+  return Math.round(parseFloat(m[1]) * (units[m[2]] || 1));
+}
+
 function parseViewbox (viewbox) {
   var bounds = viewbox.split(' ');
   return {
-    'width': parseInt(bounds[2], 10),
-    'height': parseInt(bounds[3], 10)
+    'width': parseLength(bounds[2]),
+    'height': parseLength(bounds[3])
   };
 }
 
@@ -25,8 +43,8 @@ function parseAttributes (root) {
   var height = root.match(extractorRegExps.height);
   var viewbox = root.match(extractorRegExps.viewbox);
   return {
-    'width': width && parseInt(width[2], 10),
-    'height': height && parseInt(height[2], 10),
+    'width': width && parseLength(width[2]),
+    'height': height && parseLength(height[2]),
     'viewbox': viewbox && parseViewbox(viewbox[2])
   };
 }

--- a/specs/images/valid/svg/viewbox-units.svg
+++ b/specs/images/valid/svg/viewbox-units.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="7.6875em" height="342pt">
+  <rect x="0" y="0" width="123" height="456" fill="yellow" stroke="blue" stroke-width="2" />
+</svg>


### PR DESCRIPTION
SVG allows CSS2 units in dimensions, and some SVG files use it (e.g. `width="100mm"`). This implementation makes the same assumptions as browsers that all monitors have 96 DPI and the initial font size is 16px.
