### PR TITLE
svg: use higher specifity regexp for checks

### DIFF
--- a/lib/types/svg.js
+++ b/lib/types/svg.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var svgReg = /<svg[^>]+[^>]*>/;
+var svgReg = /<svg\s([^>"']|"([^"\\]|\\[^])*"|'([^'\\]|\\[^])*')*>/;
 function isSVG (buffer) {
   return svgReg.test(buffer);
 }
 
 var extractorRegExps = {
-  'root': /<svg\s[^>]+>/,
+  'root': svgReg,
   'width': /\bwidth=(['"])([^%]+?)\1/,
   'height': /\bheight=(['"])([^%]+?)\1/,
   'viewbox': /\bviewBox=(['"])(.+?)\1/

--- a/lib/types/svg.js
+++ b/lib/types/svg.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var svgReg = /<svg\s([^>"']|"([^"\\]|\\[^])*"|'([^'\\]|\\[^])*')*>/;
+var svgReg = /<svg\s([^>"']|"[^"]*"|'[^']*')*>/;
 function isSVG (buffer) {
   return svgReg.test(buffer);
 }

--- a/specs/images/invalid/broken-quotes.svg
+++ b/specs/images/invalid/broken-quotes.svg
@@ -1,7 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 246 912"
-  width="123px"
+<svg xmlns="http://www.w3.org/2000/svg"
   onclick='alert("<(*-*)> <(^-*)' ^(*-^)> <(^-^)> ^(^_^)>")'
-  height="456px">
+  height="456px" viewBox="0 0 246 912" width="123px">
   <rect x="0" y="0" width="200" height="400" fill="yellow" stroke="blue" stroke-width="2" />
   <rect x="20" y="20" width="100" height="100" fill="red" stroke="green" stroke-width="12" />
 </svg>

--- a/specs/images/invalid/broken-quotes.svg
+++ b/specs/images/invalid/broken-quotes.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 246 912"
+  width="123px"
+  onclick='alert("<(*-*)> <(^-*)' ^(*-^)> <(^-^)> ^(^_^)>")'
+  height="456px">
+  <rect x="0" y="0" width="200" height="400" fill="yellow" stroke="blue" stroke-width="2" />
+  <rect x="20" y="20" width="100" height="100" fill="red" stroke="green" stroke-width="12" />
+</svg>

--- a/specs/images/invalid/no-quotes.svg
+++ b/specs/images/invalid/no-quotes.svg
@@ -1,0 +1,1 @@
+<svg width=100 height=100 xmlns=http://www.w3.org/2000/svg />

--- a/specs/images/valid/svg/viewbox-width-height-brackets.svg
+++ b/specs/images/valid/svg/viewbox-width-height-brackets.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 246 912"
+  width="123px"
+  onclick='alert("<(*-*)> <(^-*)^ ^(*-^)> <(^-^)> ^(^_^)>")'
+  height="456px">
+  <rect x="0" y="0" width="200" height="400" fill="yellow" stroke="blue" stroke-width="2" />
+  <rect x="20" y="20" width="100" height="100" fill="red" stroke="green" stroke-width="12" />
+</svg>


### PR DESCRIPTION
Based on http://dassur.ma/things/regexp-quote/#bonus-html-tags

Essentially for if `<svg onclick='alert(">")'>`. A gigantic increase in regex complexity though...