### PR TITLE
Always checkout JavaScript files in Unix style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
When developing on Windows, I noticed that running the tests (via `eslint`) causes a lot of errors about linebreaks not being set to LF.   

To get rid of that entirely, I suggest we tell git to always checkout out _.js_ files in Unix style (LF).