### PR TITLE
Fix: stroke-width interpreted as <svg> width

### DIFF
--- a/lib/types/svg.js
+++ b/lib/types/svg.js
@@ -7,9 +7,9 @@ function isSVG (buffer) {
 
 var extractorRegExps = {
   'root': svgReg,
-  'width': /\bwidth=(['"])([^%]+?)\1/,
-  'height': /\bheight=(['"])([^%]+?)\1/,
-  'viewbox': /\bviewBox=(['"])(.+?)\1/
+  'width': /\swidth=(['"])([^%]+?)\1/,
+  'height': /\sheight=(['"])([^%]+?)\1/,
+  'viewbox': /\sviewBox=(['"])(.+?)\1/
 };
 
 var units = {

--- a/specs/images/valid/svg/ignore-stroke-width.svg
+++ b/specs/images/valid/svg/ignore-stroke-width.svg
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'
+   stroke-width="2" width='123px' height='456px'>
+</svg>


### PR DESCRIPTION
Given `<svg ... stroke-width="x" width="w" height="h">`, image-size was pulling the width out of the `stroke-width` attribute instead of `width`.

Similarly, the `stroke-width` override values from `viewBox` in the absence of `width` and `height` attributes: `<svg ... viewBox="0 0 w h" stroke-width="x">`