### PR TITLE
Added async function around await fixing node errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,14 +62,20 @@ sizeOf('images/funny-cats.png')
 
 ### Async/Await (Typescript & ES7)
 ```javascript
-var { promisify } = require('util');
-var sizeOf = promisify(require('image-size'));
-try {
-  const dimensions = await sizeOf('images/funny-cats.png');
-  console.log(dimensions.width, dimensions.height);
-} catch (err) {
-  console.error(err);
+const { promisify } = require('util');
+const sizeOf = promisify(require('image-size'));
+
+const getDimensions = async () => {
+    try {
+        const dimensions = await sizeOf('images/funny-cats.png');
+        return dimensions;
+    } catch (err) {
+        console.error(err);
+    }
 }
+
+getDimensions().then(c => console.log(c));
+
 ```
 
 ### Multi-size


### PR DESCRIPTION
I've added an Async wrapper around the await function fixing a syntax error (SyntaxError: await is only valid in async function).
Changed the var's a const.