### PR TITLE
Mark callback parameter as optional in JSDoc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function syncFileToBuffer (filepath) {
 
 /**
  * @param {Buffer|string} input - buffer or relative/absolute path of the image file
- * @param {Function} callback - optional function for async detection
+ * @param {Function=} callback - optional function for async detection
  */
 module.exports = function (input, callback) {
 


### PR DESCRIPTION
In this way my editor (WebStorm) doesn't complain that I left out this optional parameter.

I took this notation from https://stackoverflow.com/a/16095590/261747.

Thanks for contributing and maintaining image-size.