### PR TITLE
More code overhaul

### DIFF
--- a/lib/fs.promises.ts
+++ b/lib/fs.promises.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs'
+
+// fs.promises polyfill for node 8.x
+if (!('promises' in fs)) {
+
+  class FileHandle {
+    private fd: number
+
+    constructor(fd: number) {
+      this.fd = fd
+    }
+
+    public stat() {
+      return new Promise((resolve, reject) => {
+        fs.fstat(this.fd, (err, stats) => {
+          if (err) { reject(err) } else { resolve(stats) }
+        })
+      })
+    }
+
+    public read(buffer: Buffer, offset: number, length: number, position: number) {
+      return new Promise((resolve, reject) => {
+        fs.read(this.fd, buffer, offset, length, position, (err) => {
+          if (err) { reject(err) } else { resolve() }
+        })
+      })
+    }
+
+    public close() {
+      return new Promise((resolve, reject) => {
+        fs.close(this.fd, (err) => {
+          if (err) { reject(err) } else { resolve() }
+        })
+      })
+    }
+  }
+
+  Object.defineProperty(fs, 'promises', {
+    value: {
+      open: (filepath: string, flags: string): Promise<FileHandle> => (new Promise((resolve, reject) => {
+        fs.open(filepath, flags, (err, fd) => {
+          if (err) { reject(err) } else { resolve(new FileHandle(fd)) }
+        })
+      })),
+    },
+    writable: false
+  })
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import Queue from 'queue'
 import { typeHandlers } from './types'
 import { detector } from './detector'
 import { ISizes, ISize } from './types/interface'
+import './fs.promises'
 
 type CallbackFn = (e: Error | null, b?: Buffer) => void
 type Dimensions = ISize | ISizes | null | undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,6 +276,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -367,6 +373,20 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -402,6 +422,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cli-cursor": {
@@ -556,6 +582,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -849,12 +884,6 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "expect.js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
-      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
-      "dev": true
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1021,6 +1050,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -2190,6 +2225,12 @@
           "dev": true
         }
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "12.7.5",
+    "chai": "4.2.0",
     "coveralls": "3.0.6",
     "eslint": "6.4.0",
-    "expect.js": "0.3.1",
     "glob": "7.1.4",
     "mocha": "6.2.0",
     "nyc": "14.1.1",

--- a/specs/fs-close.spec.js
+++ b/specs/fs-close.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var sinon = require('sinon');
 var fs = require('fs');
 
@@ -24,14 +24,10 @@ describe('after done reading from files', function () {
 
     it('async', function (done) {
       imageSize('specs/images/valid/jpg/large.jpg', function () {
-        expect(spy.calledOnce).to.be.ok();
+        expect(spy.calledOnce).to.be.true;
         var fsPromise = spy.returnValues[0];
         fsPromise.then(function (handle) {
-          expect(readFromClosed.bind(null, handle.fd)).to.throwException(function (e) {
-            expect(e.code).to.equal('EBADF');
-            expect(e).to.be.an(Error);
-            expect(e.message).to.match(/bad file descriptor/);
-          });
+          expect(readFromClosed.bind(null, handle.fd)).to.throw(Error, 'bad file descriptor').with.property('code', 'EBADF');
           done();
         });
       });
@@ -47,11 +43,7 @@ describe('after done reading from files', function () {
 
       imageSize('specs/images/valid/jpg/large.jpg');
 
-      expect(readFromClosed.bind(null, descriptor)).to.throwException(function (e) {
-        expect(e.code).to.equal('EBADF');
-        expect(e).to.be.an(Error);
-        expect(e.message).to.match(/bad file descriptor/);
-      });
+      expect(readFromClosed.bind(null, descriptor)).to.throw(Error, 'bad file descriptor').with.property('code', 'EBADF');
 
       fs.openSync = oldOpen;
     });

--- a/specs/invalid.spec.js
+++ b/specs/invalid.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var glob = require('glob');
 
 var imageSize = require('..');
@@ -16,15 +16,12 @@ describe('Invalid Images', function () {
       var calculate = imageSize.bind(null, file);
 
       it('should throw when called synchronously', function() {
-        expect(calculate).to.throwException(function (e) {
-          expect(e).to.be.a(TypeError);
-          expect(e.message).to.match(/^Invalid \w+$/);
-        });
+        expect(calculate).to.throw(TypeError, 'Invalid');
       });
 
       it('should callback with error when called asynchronously', function(done) {
         calculate(function (e) {
-          expect(e).to.be.a(TypeError);
+          expect(e).to.be.instanceOf(TypeError);
           expect(e.message).to.match(/^Invalid \w+$/);
           done();
         });
@@ -37,10 +34,7 @@ describe('Invalid Images', function () {
     var calculate = imageSize.bind(null, 'fakefile.jpg');
 
     it('should throw when called synchronously', function() {
-      expect(calculate).to.throwException(function (e) {
-        expect(e).to.be.a(Error);
-        expect(e.message).to.match(/^ENOENT.*$/);
-      });
+      expect(calculate).to.throw(Error, 'ENOENT');
     });
 
     it('should callback with error when called asynchronously', function(done) {

--- a/specs/others.spec.js
+++ b/specs/others.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var path = require('path');
 var fs = require('fs');
 
@@ -12,19 +12,13 @@ describe('Invalid invocation', function () {
 
   describe('invalid type', function () {
     it('should throw', function() {
-      expect(imageSize.bind(null, {})).to.throwException(function (e) {
-        expect(e).to.be.a(TypeError);
-        expect(e.message).to.be('invalid invocation');
-      });
+      expect(imageSize.bind(null, {})).to.throw(TypeError, 'invalid invocation');
     });
   });
 
   describe('non existant file', function () {
     it('should throw', function() {
-      expect(imageSize.bind(null, '/monkey/man/yo')).to.throwException(function (e) {
-        // expect(e.errno).to.be(34);
-        expect(e.code).to.be('ENOENT');
-      });
+      expect(imageSize.bind(null, '/monkey/man/yo')).to.throw(Error).with.property('code', 'ENOENT');
     });
   });
 
@@ -42,10 +36,7 @@ describe('Invalid invocation', function () {
     });
 
     it('should throw', function () {
-      expect(imageSize.bind(null, buffer)).to.throwException(function (e) {
-        expect(e).to.be.a(TypeError);
-        expect(e.message).to.contain('doesn\'t support buffer');
-      });
+      expect(imageSize.bind(null, buffer)).to.throw(TypeError, 'Tiff doesn\'t support buffer');
     });
   });
 
@@ -58,7 +49,7 @@ describe('Callback function', function () {
     var origException = process.listeners('uncaughtException').pop();
     process.removeListener('uncaughtException', origException);
     process.once('uncaughtException', function (err) {
-      expect(err).to.be(tmpError);
+      expect(err).to.equal(tmpError);
     });
 
     imageSize('specs/images/valid/jpg/sample.jpg', function() {

--- a/specs/valid.spec.js
+++ b/specs/valid.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var glob = require('glob');
 var path = require('path');
 
@@ -134,31 +134,31 @@ describe('Valid images', function () {
 
       it('should return correct size for ' + file, function() {
         var expected = sizes[file] || sizes.default;
-        expect(asyncDimensions.width).to.be(expected.width);
-        expect(asyncDimensions.height).to.be(expected.height);
+        expect(asyncDimensions.width).to.equal(expected.width);
+        expect(asyncDimensions.height).to.equal(expected.height);
         if (asyncDimensions.images) {
           asyncDimensions.images.forEach(function (item, index) {
             var expectedItem = expected.images[index];
-            expect(item.width).to.be(expectedItem.width);
-            expect(item.height).to.be(expectedItem.height);
+            expect(item.width).to.equal(expectedItem.width);
+            expect(item.height).to.equal(expectedItem.height);
             if (expectedItem.type) {
-              expect(item.type).to.be(expectedItem.type);
+              expect(item.type).to.equal(expectedItem.type);
             }
           });
         }
 
         if (expected.orientation) {
-          expect(asyncDimensions.orientation).to.be(expected.orientation);
+          expect(asyncDimensions.orientation).to.equal(expected.orientation);
         }
 
         if (type !== 'tiff') {
-          expect(bufferDimensions.width).to.be(expected.width);
-          expect(bufferDimensions.height).to.be(expected.height);
+          expect(bufferDimensions.width).to.equal(expected.width);
+          expect(bufferDimensions.height).to.equal(expected.height);
           if (bufferDimensions.images) {
             bufferDimensions.images.forEach(function (item, index) {
               var expectedItem = expected.images[index];
-              expect(item.width).to.be(expectedItem.width);
-              expect(item.height).to.be(expectedItem.height);
+              expect(item.width).to.equal(expectedItem.width);
+              expect(item.height).to.equal(expectedItem.height);
             });
           }
         }


### PR DESCRIPTION
- [x] switch internally to promises. This will be needed for the `1.0` API
- [x] switch tests from abandoned `expect.js` to `chai`