### PR TITLE
Fix imageSize typings

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -77,13 +77,13 @@ function syncFileToBuffer(filepath: string) {
 
 module.exports = exports = imageSize // backwards compatibility
 
-export function imageSize(input: Buffer): Dimensions
+export function imageSize(input: Buffer | string): Dimensions
 export function imageSize(input: string, callback: CallbackFn): void
 /**
  * @param {Buffer|string} input - buffer or relative/absolute path of the image file
  * @param {Function=} [callback] - optional function for async detection
  */
-export function imageSize(input: any, callback?: any): any {
+export function imageSize(input: Buffer | string, callback?: CallbackFn): any {
   // Handle buffer input
   if (Buffer.isBuffer(input)) {
     return lookup(input)


### PR DESCRIPTION
https://github.com/image-size/image-size#synchronous shows that you can just pass a path. However, the typings do not currently allow for that. Only a `Buffer` can be passed, unless using the callback.

This fixes said issue.