### PR TITLE
Fix tiff reader leaking file handles

### DIFF
--- a/lib/types/tiff.ts
+++ b/lib/types/tiff.ts
@@ -20,6 +20,7 @@ function readIFD(buffer: Buffer, filepath: string, isBigEndian: boolean) {
   const endBuffer = Buffer.alloc(bufferSize)
   const descriptor = fs.openSync(filepath, 'r')
   fs.readSync(descriptor, endBuffer, 0, bufferSize, ifdOffset)
+  fs.closeSync(descriptor);
 
   return endBuffer.slice(2)
 }

--- a/lib/types/tiff.ts
+++ b/lib/types/tiff.ts
@@ -20,7 +20,7 @@ function readIFD(buffer: Buffer, filepath: string, isBigEndian: boolean) {
   const endBuffer = Buffer.alloc(bufferSize)
   const descriptor = fs.openSync(filepath, 'r')
   fs.readSync(descriptor, endBuffer, 0, bufferSize, ifdOffset)
-  fs.closeSync(descriptor);
+  fs.closeSync(descriptor)
 
   return endBuffer.slice(2)
 }


### PR DESCRIPTION
I think the attached diff is pretty self-explaining. The tiff reader opens, but doesn't close file descriptors.