### PR TITLE
Export imageSize as module default

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -80,6 +80,7 @@ function syncFileToBuffer(filepath: string): Buffer {
 
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 module.exports = exports = imageSize // backwards compatibility
+export default imageSize
 export function imageSize(input: Buffer | string): ISizeCalculationResult
 export function imageSize(input: string, callback: CallbackFn): void
 /**

--- a/specs/imports.spec.ts
+++ b/specs/imports.spec.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai'
+import imageSize, { imageSize as imageSizeNamed } from '../lib'
+
+describe('Imports', () => {
+
+  it('should import both default and named export', () => {
+    expect(imageSize).to.equal(imageSizeNamed)
+  })
+
+})


### PR DESCRIPTION
Importing directly from image-size without destructuring yields the correct object, but no typings are exposed.

https://stackoverflow.com/questions/64004677/this-expression-is-not-callable-error-when-loading-image-size-through-import#comment113181041_64004677

~This PR updates the Readme to include an example of importing with ESM syntax, leading TypeScript users down the happy path.~

This PR exposes `imageSize` as the default export of the module, as suggested by @netroy https://github.com/image-size/image-size/pull/344#issuecomment-714363807

I tested this by building and linking `image-size` from this branch, and importing it in another project where it imported successfully and satisfied TypeScript's complaints.