### PR TITLE
refactor: increase TS compilation target to ES2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2018",
     "module": "commonjs",
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
We only support Node v12+, and v12 already has full ES2018 support: https://node.green/#ES2018

This would mean smaller distributed package size, and easier debugging (assuming you need to hack into `node_modules` and tweak the async methods)