### PR TITLE
perf: faster detection for large files that are not SVGs

### DIFF
--- a/lib/types/svg.ts
+++ b/lib/types/svg.ts
@@ -88,7 +88,8 @@ function calculateByViewbox(attrs: IAttributes, viewbox: IAttributes): ISize {
 }
 
 export const SVG: IImage = {
-  validate: (input) => svgReg.test(toUTF8String(input)),
+  // Scan only the first kilo-byte to speed up the check on larger files
+  validate: (input) => svgReg.test(toUTF8String(input, 0, 1000)),
 
   calculate(input) {
     const root = toUTF8String(input).match(extractorRegExps.root)


### PR DESCRIPTION
If you pass in a large Buffer, the `validate` method on the SVG type can take an extremely long time because it converts the entire Buffer into a string. An easy fix that should take care of this 99% of the time, is to first check for the presence of the bytes used to represent `<svg`. In my testing this is at least 100x faster than converting a large Buffer to a string.