### PR TITLE
Fix Browser Builds for 2.0

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "esnext",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "outDir": "dist/esm",
     "declarationDir": "dist/dts",


### PR DESCRIPTION
This PR reverts a change to typescript module settings, which seems to have broken usage in the browser.

The change that is being reverted was made in 8cd7d16cae7bbbfaa7c49eeae9bc3335ce8aa08d and seems to have been done to appease an upstream dependency which was removed in 5bc227862be7aaeac80b94b41685d18b0974e452.

All tests pass when I run it locally.