### PR TITLE
Fix: Correct JPEG Image Size Calculation by Skipping Non-`0xFF` Blocks

### DIFF
--- a/lib/types/jpg.ts
+++ b/lib/types/jpg.ts
@@ -122,7 +122,7 @@ export const JPG: IImage = {
 
       // Every JPEG block must begin with a 0xFF
       if (input[i] !== 0xff) {
-        input = input.slice(1)
+        input = input.slice(i)
         continue
       }
 


### PR DESCRIPTION
An [issue](https://github.com/withastro/astro/issues/12530) was discovered in the `astro` project, which utilizes a [vendored version](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/utils/vendor/image-size/types/jpg.ts) of `image-size`.
A [sample image](https://live.staticflickr.com/65535/54163807312_d8456912ba_o_d.jpg) with a resolution of 3730 x 5535 pixels was incorrectly reported as having a size of 48719 x 62538 pixels.

## Changes:

- Fixed the incorrect handling of non-`0xFF` blocks in JPEG image size calculations. Instead of skipping only one byte, the entire block is now skipped, resulting in improved performance and accuracy.
- Previously, the code would incorrectly parse non-0xFF blocks, leading to inaccurate image size determination. This change ensures that only valid JPEG blocks are processed, ignoring unnecessary metadata blocks.

A similar [pull reqest is submitted](https://github.com/withastro/astro/pull/12542) to the `astro` project.