### PR TITLE
Fix for looking up offset outside of buffer in JPG dimensions extraction

### DIFF
--- a/lib/types/jpg.ts
+++ b/lib/types/jpg.ts
@@ -120,6 +120,9 @@ export const JPG: IImage = {
       // read length of the next block
       const i = readUInt16BE(input, 0)
 
+      // ensure correct format
+      validateInput(input, i)
+
       // Every JPEG block must begin with a 0xFF
       if (input[i] !== 0xff) {
         input = input.slice(1)
@@ -129,9 +132,6 @@ export const JPG: IImage = {
       if (isEXIF(input)) {
         orientation = validateExifBlock(input, i)
       }
-
-      // ensure correct format
-      validateInput(input, i)
 
       // 0xFFC0 is baseline standard(SOF)
       // 0xFFC1 is baseline optimized(SOF)


### PR DESCRIPTION
Fix for reading offset and looking up buffer at that offset without validating offset > buffer.length.
This causes input[i] below being undefined in each such case.

if (input[i] !== 0xff) {

This is important when using imageSize() with Uint8Array as buffer and reading the file in chuked mode, up until it actually returns the dimensions. The following fix will cause TypeError to be thrown earlier, and now users of imageSize() will know they need to read in another chunk from the file, and call the function again, on the new, larger buffer.

To reproduce this issue, read exactly 20480 bytes from the attached image, call imageSize() on that buffer and you'll see it will incorrectly return image width of 144, while the actual width is 590.

![test](https://github.com/user-attachments/assets/33dc8c9f-d6e3-45c3-b5e7-40d998fa6e85)
