### PR TITLE
More complete tests and better type safety.

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -8,3 +8,4 @@
 * [Shinnosuke Watanabe](https://github.com/shinnn)
 * [Alexandre Morgaut](https://github.com/AMorgaut)
 * [Shmuli Margulies](https://github.com/shmuli9)
+* [Victor Widell](https://github.com/geon)

--- a/lib/detector.ts
+++ b/lib/detector.ts
@@ -1,8 +1,8 @@
-import type { imageType } from './types/index'
+import type { ImageType } from './types/index'
 import { typeHandlers, types } from './types/index'
 
 // This map helps avoid validating for every single image type
-const firstBytes = new Map<number, imageType>([
+const firstBytes = new Map<number, ImageType>([
   [0x00, 'heif'],
   [0x38, 'psd'],
   [0x42, 'bmp'],
@@ -16,7 +16,7 @@ const firstBytes = new Map<number, imageType>([
   [0xff, 'jpg'],
 ])
 
-export function detector(input: Uint8Array): imageType | undefined {
+export function detector(input: Uint8Array): ImageType | undefined {
   const byte = input[0]
   const type = firstBytes.get(byte)
   if (type && typeHandlers.get(type)!.validate(input)) {

--- a/lib/detector.ts
+++ b/lib/detector.ts
@@ -19,8 +19,8 @@ const firstBytes = new Map<number, ImageType>([
 export function detector(input: Uint8Array): ImageType | undefined {
   const byte = input[0]
   const type = firstBytes.get(byte)
-  if (type && typeHandlers.get(type)!.validate(input)) {
+  if (type && typeHandlers[type].validate(input)) {
     return type
   }
-  return types.find((type) => typeHandlers.get(type)!.validate(input))
+  return types.find((type) => typeHandlers[type].validate(input))
 }

--- a/lib/lookup.ts
+++ b/lib/lookup.ts
@@ -21,7 +21,7 @@ export function imageSize(input: Uint8Array): ISizeCalculationResult {
   // detect the file type... don't rely on the extension
   const type = detector(input)
 
-  if (typeof type !== 'undefined') {
+  if (type) {
     if (globalOptions.disabledTypes.indexOf(type) > -1) {
       throw new TypeError(`disabled file type: ${type}`)
     }

--- a/lib/lookup.ts
+++ b/lib/lookup.ts
@@ -31,8 +31,8 @@ export function imageSize(input: Uint8Array): ISizeCalculationResult {
   }
 
   // find an appropriate handler for this file type
-  const size = typeHandlers[type].calculate(input)
-  size.type = size.type ?? type
+  const result = typeHandlers[type].calculate(input)
+  const size = { ...result, type: result.type ?? type }
 
   // If multiple images, find the largest by area
   if (size.images && size.images.length > 1) {

--- a/lib/lookup.ts
+++ b/lib/lookup.ts
@@ -28,24 +28,22 @@ export function imageSize(input: Uint8Array): ISizeCalculationResult {
 
     // find an appropriate handler for this file type
     const size = typeHandlers[type].calculate(input)
-    if (size !== undefined) {
-      size.type = size.type ?? type
+    size.type = size.type ?? type
 
-      // If multiple images, find the largest by area
-      if (size.images && size.images.length > 1) {
-        const largestImage = size.images.reduce((largest, current) => {
-          return current.width * current.height > largest.width * largest.height
-            ? current
-            : largest
-        }, size.images[0])
+    // If multiple images, find the largest by area
+    if (size.images && size.images.length > 1) {
+      const largestImage = size.images.reduce((largest, current) => {
+        return current.width * current.height > largest.width * largest.height
+          ? current
+          : largest
+      }, size.images[0])
 
-        // Ensure the main result is the largest image
-        size.width = largestImage.width
-        size.height = largestImage.height
-      }
-
-      return size
+      // Ensure the main result is the largest image
+      size.width = largestImage.width
+      size.height = largestImage.height
     }
+
+    return size
   }
 
   // throw up, if we don't understand the file

--- a/lib/lookup.ts
+++ b/lib/lookup.ts
@@ -1,10 +1,10 @@
 import { detector } from './detector'
-import type { imageType } from './types/index'
+import type { ImageType } from './types/index'
 import { typeHandlers } from './types/index'
 import type { ISizeCalculationResult } from './types/interface'
 
 type Options = {
-  disabledTypes: imageType[]
+  disabledTypes: ImageType[]
 }
 
 const globalOptions: Options = {
@@ -52,6 +52,6 @@ export function imageSize(input: Uint8Array): ISizeCalculationResult {
   throw new TypeError(`unsupported file type: ${type}`)
 }
 
-export const disableTypes = (types: imageType[]): void => {
+export const disableTypes = (types: ImageType[]): void => {
   globalOptions.disabledTypes = types
 }

--- a/lib/lookup.ts
+++ b/lib/lookup.ts
@@ -27,7 +27,7 @@ export function imageSize(input: Uint8Array): ISizeCalculationResult {
     }
 
     // find an appropriate handler for this file type
-    const size = typeHandlers.get(type)!.calculate(input)
+    const size = typeHandlers[type].calculate(input)
     if (size !== undefined) {
       size.type = size.type ?? type
 

--- a/lib/lookup.ts
+++ b/lib/lookup.ts
@@ -21,33 +21,33 @@ export function imageSize(input: Uint8Array): ISizeCalculationResult {
   // detect the file type... don't rely on the extension
   const type = detector(input)
 
-  if (type) {
-    if (globalOptions.disabledTypes.indexOf(type) > -1) {
-      throw new TypeError(`disabled file type: ${type}`)
-    }
-
-    // find an appropriate handler for this file type
-    const size = typeHandlers[type].calculate(input)
-    size.type = size.type ?? type
-
-    // If multiple images, find the largest by area
-    if (size.images && size.images.length > 1) {
-      const largestImage = size.images.reduce((largest, current) => {
-        return current.width * current.height > largest.width * largest.height
-          ? current
-          : largest
-      }, size.images[0])
-
-      // Ensure the main result is the largest image
-      size.width = largestImage.width
-      size.height = largestImage.height
-    }
-
-    return size
+  if (!type) {
+    // throw up, if we don't understand the file
+    throw new TypeError(`unsupported file type: ${type}`)
   }
 
-  // throw up, if we don't understand the file
-  throw new TypeError(`unsupported file type: ${type}`)
+  if (globalOptions.disabledTypes.indexOf(type) > -1) {
+    throw new TypeError(`disabled file type: ${type}`)
+  }
+
+  // find an appropriate handler for this file type
+  const size = typeHandlers[type].calculate(input)
+  size.type = size.type ?? type
+
+  // If multiple images, find the largest by area
+  if (size.images && size.images.length > 1) {
+    const largestImage = size.images.reduce((largest, current) => {
+      return current.width * current.height > largest.width * largest.height
+        ? current
+        : largest
+    }, size.images[0])
+
+    // Ensure the main result is the largest image
+    size.width = largestImage.width
+    size.height = largestImage.height
+  }
+
+  return size
 }
 
 export const disableTypes = (types: ImageType[]): void => {

--- a/lib/types/heif.ts
+++ b/lib/types/heif.ts
@@ -1,5 +1,5 @@
 import { parseImageFormat } from '.'
-import type { IImage, ISize, ISizeCalculationResult } from './interface'
+import type { IImage, ISize } from './interface'
 import { findBox, readUInt32BE, toUTF8String } from './utils'
 
 const brandMap = {

--- a/lib/types/heif.ts
+++ b/lib/types/heif.ts
@@ -1,4 +1,5 @@
-import type { IImage, ISize } from './interface'
+import { parseImageFormat } from '.'
+import type { IImage, ISize, ISizeCalculationResult } from './interface'
 import { findBox, readUInt32BE, toUTF8String } from './utils'
 
 const brandMap = {
@@ -33,7 +34,7 @@ export const HEIF: IImage = {
       throw new TypeError('Invalid HEIF, no ipco box found')
     }
 
-    const type = toUTF8String(input, 8, 12)
+    const type = parseImageFormat(toUTF8String(input, 8, 12))
 
     const images: ISize[] = []
     let currentOffset = ipcoBox.offset + 8

--- a/lib/types/icns.ts
+++ b/lib/types/icns.ts
@@ -22,7 +22,7 @@ const FILE_LENGTH_OFFSET = 4 // MSB => BIG ENDIAN
  */
 const ENTRY_LENGTH_OFFSET = 4 // MSB => BIG ENDIAN
 
-const ICON_TYPE_SIZE: Record<string, number> = {
+const ICON_TYPE_SIZE = {
   ICON: 32,
   'ICN#': 32,
   // m => 16 x 16
@@ -65,18 +65,29 @@ const ICON_TYPE_SIZE: Record<string, number> = {
   ic10: 1024,
 }
 
+type IconType = keyof typeof ICON_TYPE_SIZE
+function isIconType(iconType: string): iconType is IconType {
+  return iconType in ICON_TYPE_SIZE
+}
+function parseIconType(iconType: string): IconType {
+  if (!isIconType(iconType)) {
+    throw new Error(`Not a valid ICON_TYPE_SIZE: ${iconType}`)
+  }
+  return iconType
+}
+
 function readImageHeader(
   input: Uint8Array,
   imageOffset: number,
-): [string, number] {
+): [IconType, number] {
   const imageLengthOffset = imageOffset + ENTRY_LENGTH_OFFSET
   return [
-    toUTF8String(input, imageOffset, imageLengthOffset),
+    parseIconType(toUTF8String(input, imageOffset, imageLengthOffset)),
     readUInt32BE(input, imageLengthOffset),
   ]
 }
 
-function getImageSize(type: string): ISize {
+function getImageSize(type: IconType): ISize {
   const size = ICON_TYPE_SIZE[type]
   return { width: size, height: size, type }
 }

--- a/lib/types/icns.ts
+++ b/lib/types/icns.ts
@@ -65,8 +65,8 @@ const ICON_TYPE_SIZE = {
   ic10: 1024,
 }
 
-type IconType = keyof typeof ICON_TYPE_SIZE
-function isIconType(iconType: string): iconType is IconType {
+export type IconType = keyof typeof ICON_TYPE_SIZE
+export function isIconType(iconType: string): iconType is IconType {
   return iconType in ICON_TYPE_SIZE
 }
 function parseIconType(iconType: string): IconType {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -45,3 +45,12 @@ export const typeHandlers = {
 
 export const types = Object.keys(typeHandlers) as readonly ImageType[]
 export type ImageType = keyof typeof typeHandlers
+function isImageType(imageType: string): imageType is ImageType {
+  return imageType in typeHandlers
+}
+export function parseImageType(imageType: string): ImageType {
+  if (!isImageType(imageType)) {
+    throw new Error(`Not a valid ImageType: ${imageType}`)
+  }
+  return imageType
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -4,7 +4,7 @@ import { CUR } from './cur'
 import { DDS } from './dds'
 import { GIF } from './gif'
 import { HEIF } from './heif'
-import { ICNS } from './icns'
+import { ICNS, IconType, isIconType } from './icns'
 import { ICO } from './ico'
 import { J2C } from './j2c'
 import { JP2 } from './jp2'
@@ -53,4 +53,26 @@ export function parseImageType(imageType: string): ImageType {
     throw new Error(`Not a valid ImageType: ${imageType}`)
   }
   return imageType
+}
+
+const extraImageFormats = ['ktx2', 'bigtiff', 'avif', 'heic'] as const
+type ExtraImageFormat = (typeof extraImageFormats)[number]
+function isExtraImageFormat(
+  extraImageFormat: string,
+): extraImageFormat is ExtraImageFormat {
+  return extraImageFormats.includes(extraImageFormat as ExtraImageFormat)
+}
+
+export type ImageFormat = ImageType | IconType | ExtraImageFormat
+export function parseImageFormat(imageFormat: string): ImageFormat {
+  if (
+    !(
+      isImageType(imageFormat) ||
+      isIconType(imageFormat) ||
+      isExtraImageFormat(imageFormat)
+    )
+  ) {
+    throw new Error(`Not a valid ImageFormat: ${imageFormat}`)
+  }
+  return imageFormat
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -44,4 +44,4 @@ export const typeHandlers = new Map([
 ] as const)
 
 export const types = Array.from(typeHandlers.keys())
-export type imageType = (typeof types)[number]
+export type ImageType = (typeof types)[number]

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -20,28 +20,28 @@ import { TGA } from './tga'
 import { TIFF } from './tiff'
 import { WEBP } from './webp'
 
-export const typeHandlers = new Map([
-  ['bmp', BMP],
-  ['cur', CUR],
-  ['dds', DDS],
-  ['gif', GIF],
-  ['heif', HEIF],
-  ['icns', ICNS],
-  ['ico', ICO],
-  ['j2c', J2C],
-  ['jp2', JP2],
-  ['jpg', JPG],
-  ['jxl', JXL],
-  ['jxl-stream', JXLStream],
-  ['ktx', KTX],
-  ['png', PNG],
-  ['pnm', PNM],
-  ['psd', PSD],
-  ['svg', SVG],
-  ['tga', TGA],
-  ['tiff', TIFF],
-  ['webp', WEBP],
-] as const)
+export const typeHandlers = {
+  bmp: BMP,
+  cur: CUR,
+  dds: DDS,
+  gif: GIF,
+  heif: HEIF,
+  icns: ICNS,
+  ico: ICO,
+  j2c: J2C,
+  jp2: JP2,
+  jpg: JPG,
+  jxl: JXL,
+  'jxl-stream': JXLStream,
+  ktx: KTX,
+  png: PNG,
+  pnm: PNM,
+  psd: PSD,
+  svg: SVG,
+  tga: TGA,
+  tiff: TIFF,
+  webp: WEBP,
+} as const
 
-export const types = Array.from(typeHandlers.keys())
-export type ImageType = (typeof types)[number]
+export const types = Object.keys(typeHandlers) as readonly ImageType[]
+export type ImageType = keyof typeof typeHandlers

--- a/lib/types/interface.ts
+++ b/lib/types/interface.ts
@@ -1,19 +1,19 @@
 import { ImageFormat } from '.'
 
-export interface ISize {
+export interface ISizeCalculationResult {
   width: number
   height: number
   orientation?: number
+  type: ImageFormat
+  images?: ISize[]
+}
+
+export interface IImageCalculationResult
+  extends Omit<ISizeCalculationResult, 'type'> {
   type?: ImageFormat
 }
 
-export type IImageCalculationResult = {
-  images?: ISize[]
-} & ISize
-
-export type ISizeCalculationResult = {
-  type: ImageFormat
-} & Omit<IImageCalculationResult, 'type'>
+export type ISize = Omit<IImageCalculationResult, 'images'>
 
 export interface IImage {
   validate: (input: Uint8Array) => boolean

--- a/lib/types/interface.ts
+++ b/lib/types/interface.ts
@@ -11,7 +11,9 @@ export type IImageCalculationResult = {
   images?: ISize[]
 } & ISize
 
-export type ISizeCalculationResult = IImageCalculationResult
+export type ISizeCalculationResult = {
+  type: ImageFormat
+} & Omit<IImageCalculationResult, 'type'>
 
 export interface IImage {
   validate: (input: Uint8Array) => boolean

--- a/lib/types/interface.ts
+++ b/lib/types/interface.ts
@@ -7,11 +7,13 @@ export interface ISize {
   type?: ImageFormat
 }
 
-export type ISizeCalculationResult = {
+export type IImageCalculationResult = {
   images?: ISize[]
 } & ISize
 
+export type ISizeCalculationResult = IImageCalculationResult
+
 export interface IImage {
   validate: (input: Uint8Array) => boolean
-  calculate: (input: Uint8Array) => ISizeCalculationResult
+  calculate: (input: Uint8Array) => IImageCalculationResult
 }

--- a/lib/types/interface.ts
+++ b/lib/types/interface.ts
@@ -1,8 +1,10 @@
+import { ImageFormat } from '.'
+
 export interface ISize {
   width: number
   height: number
   orientation?: number
-  type?: string
+  type?: ImageFormat
 }
 
 export type ISizeCalculationResult = {

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -14,22 +14,27 @@ const sizes: Record<string, ISizeCalculationResult> = {
     height: 456,
   },
   'specs/images/valid/cur/sample.cur': {
+    type: 'cur',
     width: 32,
     height: 32,
   },
   'specs/images/valid/ico/sample.ico': {
+    type: 'ico',
     width: 32,
     height: 32,
   },
   'specs/images/valid/ico/sample-compressed.ico': {
+    type: 'ico',
     width: 32,
     height: 32,
   },
   'specs/images/valid/ico/sample-256.ico': {
+    type: 'ico',
     width: 256,
     height: 256,
   },
   'specs/images/valid/ico/sample-256-compressed.ico': {
+    type: 'ico',
     width: 256,
     height: 256,
   },
@@ -49,6 +54,7 @@ const sizes: Record<string, ISizeCalculationResult> = {
     type: 'icns',
   },
   'specs/images/valid/ico/multi-size.ico': {
+    type: 'ico',
     width: 256,
     height: 256,
     images: [
@@ -64,6 +70,7 @@ const sizes: Record<string, ISizeCalculationResult> = {
     ],
   },
   'specs/images/valid/ico/multi-size-compressed.ico': {
+    type: 'ico',
     width: 256,
     height: 256,
     images: [
@@ -79,58 +86,71 @@ const sizes: Record<string, ISizeCalculationResult> = {
     ],
   },
   'specs/images/valid/jpg/large.jpg': {
+    type: 'jpg',
     width: 1600,
     height: 1200,
     orientation: 1,
   },
   'specs/images/valid/jpg/very-large.jpg': {
+    type: 'jpg',
     width: 4800,
     height: 3600,
     orientation: 1,
   },
   'specs/images/valid/jpg/1x2-flipped-big-endian.jpg': {
+    type: 'jpg',
     width: 1,
     height: 2,
     orientation: 8,
   },
   'specs/images/valid/jpg/1x2-flipped-little-endian.jpg': {
+    type: 'jpg',
     width: 1,
     height: 2,
     orientation: 8,
   },
   'specs/images/valid/png/sample_fried.png': {
+    type: 'png',
     width: 128,
     height: 68,
   },
   'specs/images/valid/jxl-stream/small_square.jxl': {
+    type: 'jxl-stream',
     width: 64,
     height: 64,
   },
   'specs/images/valid/jxl-stream/small_rect.jxl': {
+    type: 'jxl-stream',
     width: 120,
     height: 80,
   },
   'specs/images/valid/jxl-stream/large_explicit.jxl': {
+    type: 'jxl-stream',
     width: 3000,
     height: 2000,
   },
   'specs/images/valid/jxl-stream/large_16_9.jxl': {
+    type: 'jxl-stream',
     width: 1920,
     height: 1080,
   },
   'specs/images/valid/jxl-stream/max_small.jxl': {
+    type: 'jxl-stream',
     width: 256,
     height: 256,
   },
   'specs/images/valid/jxl-stream/min_large.jxl': {
+    type: 'jxl-stream',
     width: 257,
     height: 257,
   },
   'specs/images/valid/heif/sample.heic': {
+    type: 'heic',
     width: 123,
     height: 456,
   },
   'specs/images/valid/heif/sample-multi.heic': {
+    type: 'heic',
     width: 123,
     height: 456,
     images: [
@@ -164,6 +184,9 @@ describe('Valid images', () => {
           expected.orientation,
           'orientation',
         )
+        if (expected.type) {
+          assert.equal(dimensions.type, expected.type, 'type')
+        }
       })
     })
   }

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -156,9 +156,7 @@ describe('Valid images', () => {
         const expected = sizes[file as keyof typeof sizes] || sizes.default
         assert.equal(dimensions.width, expected.width, 'width')
         assert.equal(dimensions.height, expected.height, 'height')
-        if (dimensions.images) {
-          assert.deepStrictEqual(dimensions.images, expected.images, 'images')
-        }
+        assert.deepStrictEqual(dimensions.images, expected.images, 'images')
 
         if (expected.orientation) {
           assert.equal(

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -411,7 +411,7 @@ describe('Valid images', () => {
       it(file, async () => {
         const dimensions = await imageSizeFromFile(file)
 
-        const expected = sizes[file as keyof typeof sizes]
+        const expected = sizes[file]
 
         // The `compression` property is created for tiff images, but there is no typing for it.
         // It is deleted to not fail test.

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -157,8 +157,8 @@ describe('Valid images', () => {
         const dimensions = await imageSizeFromFile(file)
 
         const expected = sizes[file as keyof typeof sizes] || sizes.default
-        assert.equal(dimensions.width, expected.width)
-        assert.equal(dimensions.height, expected.height)
+        assert.equal(dimensions.width, expected.width, 'width')
+        assert.equal(dimensions.height, expected.height, 'height')
         if (dimensions.images) {
           dimensions.images.forEach((item, index) => {
             if (expected.images) {
@@ -173,7 +173,11 @@ describe('Valid images', () => {
         }
 
         if (expected.orientation) {
-          assert.equal(dimensions.orientation, expected.orientation)
+          assert.equal(
+            dimensions.orientation,
+            expected.orientation,
+            'orientation',
+          )
         }
       })
     })

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -168,16 +168,7 @@ describe('Valid images', () => {
         assert.equal(dimensions.width, expected.width, 'width')
         assert.equal(dimensions.height, expected.height, 'height')
         if (dimensions.images) {
-          dimensions.images.forEach((item, index) => {
-            if (expected.images) {
-              const expectedItem = expected.images[index]
-              assert.equal(item.width, expectedItem.width)
-              assert.equal(item.height, expectedItem.height)
-              if (expectedItem.type) {
-                assert.equal(item.type, expectedItem.type)
-              }
-            }
-          })
+          assert.deepStrictEqual(dimensions.images, expected.images, 'images')
         }
 
         if (expected.orientation) {

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -158,6 +158,246 @@ const sizes: Record<string, ISizeCalculationResult> = {
       { width: 63, height: 64 },
     ],
   },
+  'specs/images/valid/webp/lossy.webp': {
+    width: 123,
+    height: 456,
+    type: 'webp',
+  },
+  'specs/images/valid/webp/lossless.webp': {
+    width: 123,
+    height: 456,
+    type: 'webp',
+  },
+  'specs/images/valid/webp/extended.webp': {
+    width: 123,
+    height: 456,
+    type: 'webp',
+  },
+  'specs/images/valid/tiff/little-endian.tiff': {
+    width: 123,
+    height: 456,
+    type: 'tiff',
+  },
+  'specs/images/valid/tiff/jpeg.tiff': {
+    width: 123,
+    height: 456,
+    type: 'tiff',
+  },
+  'specs/images/valid/tiff/bigtiff-little-endian.tiff': {
+    width: 123,
+    height: 456,
+    type: 'bigtiff',
+  },
+  'specs/images/valid/tiff/bigtiff-jpeg.tiff': {
+    width: 123,
+    height: 456,
+    type: 'bigtiff',
+  },
+  'specs/images/valid/tiff/bigtiff-big-endian.tiff': {
+    width: 123,
+    height: 456,
+    type: 'bigtiff',
+  },
+  'specs/images/valid/tiff/big-endian.tiff': {
+    width: 123,
+    height: 456,
+    type: 'tiff',
+  },
+  'specs/images/valid/tga/sample.tga': {
+    width: 123,
+    height: 456,
+    type: 'tga',
+  },
+  'specs/images/valid/svg/width-height.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox-width.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox-width-height.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox-width-height-brackets.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox-units.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox-lowercase.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/viewbox-height.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/units-inches.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/single-quotes.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/percentage.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/ignore-stroke-width.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/svg/exponent-width-height.svg': {
+    width: 123,
+    height: 456,
+    type: 'svg',
+  },
+  'specs/images/valid/psd/sample.psd': {
+    width: 123,
+    height: 456,
+    type: 'psd',
+  },
+  'specs/images/valid/pnm/sample.ppm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample.pgm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample.pfm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample.pbm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample.pam': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample-ascii.ppm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample-ascii.pgm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/pnm/sample-ascii.pbm': {
+    width: 123,
+    height: 456,
+    type: 'pnm',
+  },
+  'specs/images/valid/png/sample.png': {
+    width: 123,
+    height: 456,
+    type: 'png',
+  },
+  'specs/images/valid/ktx/sample.ktx2': {
+    width: 123,
+    height: 456,
+    type: 'ktx2',
+  },
+  'specs/images/valid/ktx/sample.ktx': {
+    width: 123,
+    height: 456,
+    type: 'ktx',
+  },
+  'specs/images/valid/jxl-stream/sample.jxl.stream': {
+    width: 123,
+    height: 456,
+    type: 'jxl-stream',
+  },
+  'specs/images/valid/jxl/sample.jxl': {
+    width: 123,
+    height: 456,
+    type: 'jxl',
+  },
+  'specs/images/valid/jpg/sampleExported.jpg': {
+    width: 123,
+    height: 456,
+    type: 'jpg',
+  },
+  'specs/images/valid/jpg/sample.jpg': {
+    width: 123,
+    height: 456,
+    type: 'jpg',
+  },
+  'specs/images/valid/jpg/progressive.jpg': {
+    width: 123,
+    height: 456,
+    type: 'jpg',
+  },
+  'specs/images/valid/jpg/optimized.jpg': {
+    width: 123,
+    height: 456,
+    type: 'jpg',
+  },
+  'specs/images/valid/jp2/sample.jp2': {
+    width: 123,
+    height: 456,
+    type: 'jp2',
+  },
+  'specs/images/valid/heif/sample.heif': {
+    width: 123,
+    height: 456,
+    type: 'heic',
+  },
+  'specs/images/valid/heif/sample.avif': {
+    width: 123,
+    height: 456,
+    type: 'avif',
+  },
+  'specs/images/valid/heif/sample-garbled.avif': {
+    width: 123,
+    height: 456,
+    type: 'avif',
+  },
+  'specs/images/valid/gif/sample.gif': {
+    width: 123,
+    height: 456,
+    type: 'gif',
+  },
+  'specs/images/valid/dds/sample.dds': {
+    width: 123,
+    height: 456,
+    type: 'dds',
+  },
+  'specs/images/valid/bmp/sample.bmp': {
+    width: 123,
+    height: 456,
+    type: 'bmp',
+  },
 }
 
 // Test all valid files

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -416,15 +416,12 @@ describe('Valid images', () => {
         const dimensions = await imageSizeFromFile(file)
 
         const expected = sizes[file as keyof typeof sizes] || sizes.default
-        assert.equal(dimensions.width, expected.width, 'width')
-        assert.equal(dimensions.height, expected.height, 'height')
-        assert.deepStrictEqual(dimensions.images, expected.images, 'images')
-        assert.equal(
-          dimensions.orientation,
-          expected.orientation,
-          'orientation',
-        )
-        assert.equal(dimensions.type, expected.type, 'type')
+
+        // The `compression` property is created for tiff images, but there is no typing for it.
+        // It is deleted to not fail test.
+        delete (dimensions as any).compression
+
+        assert.deepStrictEqual(dimensions, expected)
       })
     })
   }

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -9,10 +9,6 @@ import type { ISizeCalculationResult } from '../lib/types/interface'
 import { imageSizeFromFile } from '../lib/fromFile'
 
 const sizes: Record<string, ISizeCalculationResult> = {
-  default: {
-    width: 123,
-    height: 456,
-  },
   'specs/images/valid/cur/sample.cur': {
     type: 'cur',
     width: 32,
@@ -415,7 +411,7 @@ describe('Valid images', () => {
       it(file, async () => {
         const dimensions = await imageSizeFromFile(file)
 
-        const expected = sizes[file as keyof typeof sizes] || sizes.default
+        const expected = sizes[file as keyof typeof sizes]
 
         // The `compression` property is created for tiff images, but there is no typing for it.
         // It is deleted to not fail test.

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -139,6 +139,14 @@ const sizes: Record<string, ISizeCalculationResult> = {
       { width: 16, height: 16 },
     ],
   },
+  'specs/images/valid/heif/sample-multi.heic': {
+    width: 123,
+    height: 456,
+    images: [
+      { width: 123, height: 456 },
+      { width: 63, height: 64 },
+    ],
+  },
 }
 
 // Test all valid files

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -424,9 +424,7 @@ describe('Valid images', () => {
           expected.orientation,
           'orientation',
         )
-        if (expected.type) {
-          assert.equal(dimensions.type, expected.type, 'type')
-        }
+        assert.equal(dimensions.type, expected.type, 'type')
       })
     })
   }

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -159,14 +159,11 @@ describe('Valid images', () => {
         assert.equal(dimensions.width, expected.width, 'width')
         assert.equal(dimensions.height, expected.height, 'height')
         assert.deepStrictEqual(dimensions.images, expected.images, 'images')
-
-        if (expected.orientation) {
-          assert.equal(
-            dimensions.orientation,
-            expected.orientation,
-            'orientation',
-          )
-        }
+        assert.equal(
+          dimensions.orientation,
+          expected.orientation,
+          'orientation',
+        )
       })
     })
   }

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -81,10 +81,12 @@ const sizes: Record<string, ISizeCalculationResult> = {
   'specs/images/valid/jpg/large.jpg': {
     width: 1600,
     height: 1200,
+    orientation: 1,
   },
   'specs/images/valid/jpg/very-large.jpg': {
     width: 4800,
     height: 3600,
+    orientation: 1,
   },
   'specs/images/valid/jpg/1x2-flipped-big-endian.jpg': {
     width: 1,

--- a/specs/valid.spec.ts
+++ b/specs/valid.spec.ts
@@ -127,17 +127,6 @@ const sizes: Record<string, ISizeCalculationResult> = {
   'specs/images/valid/heif/sample.heic': {
     width: 123,
     height: 456,
-    images: [
-      { width: 256, height: 256 },
-      { width: 128, height: 128 },
-      { width: 96, height: 96 },
-      { width: 72, height: 72 },
-      { width: 64, height: 64 },
-      { width: 48, height: 48 },
-      { width: 32, height: 32 },
-      { width: 24, height: 24 },
-      { width: 16, height: 16 },
-    ],
   },
   'specs/images/valid/heif/sample-multi.heic': {
     width: 123,


### PR DESCRIPTION
I noticed the `type` property returned by `imageSize` was optional and typed as a string. Now it is required and typed as a string union of all supported image formats.