### PR TITLE
fix: install corepack from npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ commands:
   build:
     steps:
       - checkout
-      - run: corepack enable && corepack prepare --activate
+      - run: npm i -g corepack && corepack prepare --activate
       - run: node --version && yarn --version
       - restore_cache:
           keys:


### PR DESCRIPTION
Corepack is not going to be distributed with Node.js v25+
TSC vote https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616

This PR updates the command to globally installing corepack.