### PR TITLE
Limit keys for object to width and height

### DIFF
--- a/lib/types/pnm.ts
+++ b/lib/types/pnm.ts
@@ -45,13 +45,15 @@ const handlers: Record<string, Handler> = {
       }
       const [key, value] = line.split(' ')
       if (key && value) {
-        size[key.toLowerCase()] = Number.parseInt(value, 10)
-      }
-      if (size.height && size.width) {
-        break
+        const lower = key.toLowerCase()
+        if (lower === 'height' || lower === 'width') {
+          size[key.toLowerCase()] = Number.parseInt(value, 10)
+          if (size.height && size.width) {
+            break
+          }
+        }
       }
     }
-
     if (size.height && size.width) {
       return {
         height: size.height,

--- a/lib/types/pnm.ts
+++ b/lib/types/pnm.ts
@@ -47,7 +47,7 @@ const handlers: Record<string, Handler> = {
       if (key && value) {
         const lower = key.toLowerCase()
         if (lower === 'height' || lower === 'width') {
-          size[key.toLowerCase()] = Number.parseInt(value, 10)
+          size[lower] = Number.parseInt(value, 10)
           if (size.height && size.width) {
             break
           }


### PR DESCRIPTION
This ensures that the constructor or prototype cannot be set (for example):

```
size[__proto__] = Number.parseInt(value, 10)
size[constructor] = Number.parseInt(value, 10)
```