### PR TITLE
Fix getting size for `.tif` files where the tag is not contained in first 512kb

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -171,7 +171,7 @@ console.log(width, height, orientation)
 # Limitations
 
 1. **Partial File Reading**
-   - Only reads image headers, not full files. The only exception is when `imageSizeFromFile` fails to read the image size from the initial 512kb of the file - in this case, a larger part of the file is re-read.
+   - Only reads image headers, not full files
    - Some corrupted images might still report dimensions
 
 2. **SVG Limitations**

--- a/Readme.md
+++ b/Readme.md
@@ -82,20 +82,6 @@ const { setConcurrency } = require('image-size/fromFile')
 setConcurrency(123456)
 ```
 
-Note: By default, `image-size` reads the first 512kb of the local file only. When dealing with images where the image size is only specified in a later part of the file, pass a larger `maxInputSize` parameter as so:
-
-```javascript
-import { imageSizeFromFile } from 'image-size/fromFile'
-// or
-const { imageSizeFromFile } = require('image-size/fromFile')
-
-const dimensions = await imageSizeFromFile(
-  'graphics/myLargeFile.tiff',
-  10 * 512 * 1024,
-) // The default value for `maxInputSize` is `512 * 1024`, aka 512kb.
-console.log(dimensions.width, dimensions.height)
-```
-
 ### Reading from a file Syncronously (not recommended) ⚠️
 v1.x of this library had a sync API, that internally used sync file reads.  
 
@@ -185,7 +171,7 @@ console.log(width, height, orientation)
 # Limitations
 
 1. **Partial File Reading**
-   - Only reads image headers, not full files. When reading images from file, you can optionally pass a larger `maxInputSize` argument.
+   - Only reads image headers, not full files. The only exception is when `imageSizeFromFile` fails to read the image size from the initial 512kb of the file - in this case, a larger part of the file is re-read.
    - Some corrupted images might still report dimensions
 
 2. **SVG Limitations**

--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,20 @@ const { setConcurrency } = require('image-size/fromFile')
 setConcurrency(123456)
 ```
 
+Note: By default, `image-size` reads the first 512kb of the local file only. When dealing with images where the image size is only specified in a later part of the file, pass a larger `maxInputSize` parameter as so:
+
+```javascript
+import { imageSizeFromFile } from 'image-size/fromFile'
+// or
+const { imageSizeFromFile } = require('image-size/fromFile')
+
+const dimensions = await imageSizeFromFile(
+  'graphics/myLargeFile.tiff',
+  10 * 512 * 1024,
+) // The default value for `maxInputSize` is `512 * 1024`, aka 512kb.
+console.log(dimensions.width, dimensions.height)
+```
+
 ### Reading from a file Syncronously (not recommended) ⚠️
 v1.x of this library had a sync API, that internally used sync file reads.  
 
@@ -171,7 +185,7 @@ console.log(width, height, orientation)
 # Limitations
 
 1. **Partial File Reading**
-   - Only reads image headers, not full files
+   - Only reads image headers, not full files. When reading images from file, you can optionally pass a larger `maxInputSize` argument.
    - Some corrupted images might still report dimensions
 
 2. **SVG Limitations**

--- a/lib/types/tiff.ts
+++ b/lib/types/tiff.ts
@@ -40,6 +40,12 @@ function readIFD(input: Uint8Array, { isBigEndian, isBigTiff }: TIFFFormat) {
   const entryCountSize = isBigTiff
     ? CONSTANTS.COUNT_SIZE.BIG
     : CONSTANTS.COUNT_SIZE.STANDARD
+  if (ifdOffset + entryCountSize > input.byteLength) {
+    throw new TypeError(
+      'Tiff tags are outside of the read file part, starting at index ' +
+        ifdOffset,
+    )
+  }
   return input.slice(ifdOffset + entryCountSize)
 }
 

--- a/lib/types/tiff.ts
+++ b/lib/types/tiff.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import type { IImage, ISize } from './interface'
 import { readUInt, readUInt64, toHexString, toUTF8String } from './utils'
+import { ImageSizeInfoOutOfBoundsError } from '../utils/customErrors'
 
 const CONSTANTS = {
   TAG: {
@@ -41,9 +42,10 @@ function readIFD(input: Uint8Array, { isBigEndian, isBigTiff }: TIFFFormat) {
     ? CONSTANTS.COUNT_SIZE.BIG
     : CONSTANTS.COUNT_SIZE.STANDARD
   if (ifdOffset + entryCountSize > input.byteLength) {
-    throw new TypeError(
+    throw new ImageSizeInfoOutOfBoundsError(
       'Tiff tags are outside of the read file part, starting at index ' +
         ifdOffset,
+      ifdOffset,
     )
   }
   return input.slice(ifdOffset + entryCountSize)

--- a/lib/utils/customErrors.ts
+++ b/lib/utils/customErrors.ts
@@ -1,0 +1,10 @@
+export class ImageSizeInfoOutOfBoundsError extends Error {
+  requiredStartOffset: number
+
+  constructor(message: string, requiredStartOffset: number) {
+    super(message)
+    this.name = 'ImageSizeInfoOutOfBoundsError'
+    this.requiredStartOffset = requiredStartOffset
+    Object.setPrototypeOf(this, ImageSizeInfoOutOfBoundsError.prototype)
+  }
+}

--- a/specs/others.spec.ts
+++ b/specs/others.spec.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import { after, before, describe, it } from 'node:test'
 import { disableTypes, imageSize, types } from '../lib'
 import { imageSizeFromFile } from '../lib/fromFile'
+import { ImageSizeInfoOutOfBoundsError } from '../lib/utils/customErrors'
 
 // If something other than a buffer or filepath is passed
 describe('Invalid invocation', () => {
@@ -18,8 +19,8 @@ describe('Invalid invocation', () => {
       readSync(descriptor, buffer, 0, bufferSize, 0)
       assert.throws(
         () => imageSize(buffer),
-        TypeError,
-        'Invalid Tiff. Missing tags',
+        ImageSizeInfoOutOfBoundsError,
+        'ImageSizeInfoOutOfBoundsError: Tiff tags are outside of the read file part, starting at index 157220',
       )
     })
   })


### PR DESCRIPTION
This PR fixes one specific blocker my team ran into: Our code is dealing with `.tif` files, where the image size tag appears later than in the first 512kb that are read in the `imageSizeFromFile` function.

This PR:
- Adds a more specific error message for this case (see 5fc8006c1c833118b2ab8eeb8d0435cf7e0a650b)
- Tries to allow package users to avoid this issue if they also have such images. Two approaches have been implemented:
   - A "dumb" approach: Allow package user to configure a custom value for how much of the image file is loaded from disk to compute the image size. This was implemented in 50db3626bac0d865f7a59306ffcc6cd25a2ea9f3. This approach would be sufficient for my team, and is quick to understand / review.
   - A "smart" approach: Image type handlers can throw a custom `ImageSizeInfoOutOfBoundsError` error to inform the `imageSizeFromFile` function that more of the file needs to be read to determine the image size, in which case the function reads more of the file, and re-tries. This custom error is currently only implemented for `.tiff` files, since I had such files that I could test with, but the pattern could be easily replicated for other image handlers. This approach was implemented in a39675f01b5f1be08a105a394454d1714282e033 and refined in e2b213136ac17906228923bd24f9263fd6031c97. The benefit is that library users don't need to overthink magic numbers, and there's less "configuration surface" of the package.

Either one of the 2 approaches would be highly appreciated. Just let me know which one you prefer, and if it's the 1st approach, I'll just remove the commits for the 2nd approach. 

I don't have rights to publicly share the actual images where this issue came up, but might be able to create such files upon request, if required. With such a test file, an automated test case could be added to prevent regressions in the chosen approach.

Please let me know if there's anything I need to change to make this contribution mergeable. Thank you!