### PR TITLE
Increase the SVG scan size to 10Kb

### DIFF
--- a/lib/types/svg.ts
+++ b/lib/types/svg.ts
@@ -88,8 +88,8 @@ function calculateByViewbox(attrs: IAttributes, viewbox: IAttributes): ISize {
 }
 
 export const SVG: IImage = {
-  // Scan only the first kilo-byte to speed up the check on larger files
-  validate: (input) => svgReg.test(toUTF8String(input, 0, 1000)),
+  // Scan only the first 10 kilo-bytes to speed up the check on larger files
+  validate: (input) => svgReg.test(toUTF8String(input, 0, 10000)),
 
   calculate(input) {
     const root = toUTF8String(input).match(extractorRegExps.root)


### PR DESCRIPTION
This takes care of the issue when the SVG is prepended with a lot of metadata preventing the RegEx from returning a match.

Fixes https://github.com/image-size/image-size/issues/397