### PR TITLE
security: Fix icns DoS if header is 0

### DIFF
--- a/lib/types/icns.ts
+++ b/lib/types/icns.ts
@@ -95,7 +95,7 @@ export const ICNS: IImage = {
       const imageHeader = readImageHeader(input, imageOffset)
       const imageSize = getImageSize(imageHeader[0])
       images.push(imageSize)
-      imageOffset += imageHeader[1]
+      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8
     }
 
     if (images.length === 0) {


### PR DESCRIPTION
Related to https://github.com/image-size/image-size/pull/439, passing in an empty header .icns file will result in an infinite loop.