### PR TITLE
Make SVG validation more robust

### DIFF
--- a/lib/types/svg.ts
+++ b/lib/types/svg.ts
@@ -1,5 +1,6 @@
 import type { IImage, ISize } from './interface'
 import { toUTF8String } from './utils'
+import { Buffer } from 'node:buffer'
 
 interface IAttributes {
   width: number | null
@@ -88,8 +89,9 @@ function calculateByViewbox(attrs: IAttributes, viewbox: IAttributes): ISize {
 }
 
 export const SVG: IImage = {
-  // Scan only the first kilo-byte to speed up the check on larger files
-  validate: (input) => svgReg.test(toUTF8String(input, 0, 1000)),
+  // svgReg.test requires conversion to string and finding the terminal '>',
+  // which can be slow for large files
+  validate: (input) => Buffer.from(input.buffer).includes('<svg'),
 
   calculate(input) {
     const root = toUTF8String(input).match(extractorRegExps.root)


### PR DESCRIPTION
In image-size/image-size#375, SVG validation was changed to searching for the `<svg ...>` tag in the first 1000 bytes. This is quite brittle and yields false negatives for draw.io SVG exports, whose <svg> tag is very long. Instead of limiting length and requiring a terminal `>`, just search the Uint8Array for `<svg` without string conversion.

This is an example of an SVG whose `<svg ...>` spans greater than the first 1000 bytes of the file:

![Untitled Diagram drawio](https://github.com/user-attachments/assets/593d4875-cac1-4f8d-94ae-3c5f612b43f6)

Another problem, that's way less likely, is that the 999–1000 partition could be inside of a multi-byte code point, so the UTF-8 decode could fail regardless of whether the first 1000 bytes contained a full `<svg>` tag.

@netroy: I'm not sure if importing Buffer is ok here.